### PR TITLE
fix(rust): fix manual release workflow_dispatch not running

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,14 @@ on:
       - '.github/workflows/rust.yml'
   workflow_dispatch:
     inputs:
+      release_mode:
+        description: 'Manual release mode'
+        required: true
+        type: choice
+        default: 'instant'
+        options:
+          - instant
+          - changelog-pr
       bump_type:
         description: 'Version bump type'
         required: true
@@ -113,14 +121,19 @@ jobs:
     name: Lint and Format Check
     runs-on: ubuntu-latest
     needs: [detect-changes]
+    # Note: always() is required because detect-changes is skipped on workflow_dispatch,
+    # and without always(), this job would also be skipped even though its condition includes workflow_dispatch.
+    # See: https://github.com/actions/runner/issues/491
     if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.rs-changed == 'true' ||
-      needs.detect-changes.outputs.toml-changed == 'true' ||
-      needs.detect-changes.outputs.mjs-changed == 'true' ||
-      needs.detect-changes.outputs.docs-changed == 'true' ||
-      needs.detect-changes.outputs.workflow-changed == 'true'
+      always() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.rs-changed == 'true' ||
+        needs.detect-changes.outputs.toml-changed == 'true' ||
+        needs.detect-changes.outputs.mjs-changed == 'true' ||
+        needs.detect-changes.outputs.docs-changed == 'true' ||
+        needs.detect-changes.outputs.workflow-changed == 'true'
+      )
     steps:
       - uses: actions/checkout@v4
 
@@ -192,7 +205,7 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
     needs: [lint, test]
-    if: always() && needs.lint.result == 'success' && needs.test.result == 'success'
+    if: always() && !cancelled() && needs.lint.result == 'success' && needs.test.result == 'success'
     steps:
       - uses: actions/checkout@v4
 
@@ -220,7 +233,12 @@ jobs:
   auto-release:
     name: Auto Release
     needs: [lint, test, build]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Note: always() ensures consistent behavior with other jobs that depend on jobs using always().
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -336,11 +354,17 @@ jobs:
             --tag-prefix "rust-v" \
             --crates-io-url "https://crates.io/crates/$PACKAGE_NAME"
 
-  # === MANUAL RELEASE ===
+  # === MANUAL INSTANT RELEASE ===
   manual-release:
-    name: Manual Release
+    name: Instant Release
     needs: [lint, test, build]
-    if: github.event_name == 'workflow_dispatch'
+    # Note: always() is required to evaluate the condition when dependencies use always().
+    # The build job ensures lint and test passed before this job runs.
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_mode == 'instant' &&
+      needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -435,3 +459,75 @@ jobs:
             --repository "${{ github.repository }}" \
             --tag-prefix "rust-v" \
             --crates-io-url "https://crates.io/crates/$PACKAGE_NAME"
+
+  # === MANUAL CHANGELOG PR ===
+  changelog-pr:
+    name: Create Changelog PR
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changelog-pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Create changelog fragment
+        run: |
+          BUMP_TYPE="${{ github.event.inputs.bump_type }}"
+          DESCRIPTION="${{ github.event.inputs.description }}"
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          FRAGMENT_FILE="changelog.d/${TIMESTAMP}-manual-${BUMP_TYPE}.md"
+
+          # Determine changelog category based on bump type
+          case "$BUMP_TYPE" in
+            major)
+              CATEGORY="breaking"
+              ;;
+            minor)
+              CATEGORY="added"
+              ;;
+            patch)
+              CATEGORY="fixed"
+              ;;
+          esac
+
+          # Create changelog fragment
+          mkdir -p changelog.d
+          if [ -n "$DESCRIPTION" ]; then
+            echo "- ${DESCRIPTION}" > "$FRAGMENT_FILE"
+          else
+            echo "- Manual ${BUMP_TYPE} release" > "$FRAGMENT_FILE"
+          fi
+
+          echo "Created changelog fragment: $FRAGMENT_FILE"
+          cat "$FRAGMENT_FILE"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(rust): add changelog for manual ${{ github.event.inputs.bump_type }} release'
+          branch: changelog-manual-rust-release-${{ github.run_id }}
+          delete-branch: true
+          title: 'chore(rust): manual ${{ github.event.inputs.bump_type }} release'
+          body: |
+            ## Manual Release Request (Rust)
+
+            This PR was created by a manual workflow trigger to prepare a **${{ github.event.inputs.bump_type }}** release for the Rust package.
+
+            ### Release Details
+            - **Type:** ${{ github.event.inputs.bump_type }}
+            - **Description:** ${{ github.event.inputs.description || 'Manual release' }}
+            - **Triggered by:** @${{ github.actor }}
+
+            ### Next Steps
+            1. Review the changelog fragment in this PR
+            2. Merge this PR to main
+            3. The automated release workflow will publish to crates.io and create a GitHub release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/lino-env/issues/24
-Your prepared branch: issue-24-e5cb18c72ce6
-Your prepared working directory: /tmp/gh-issue-solver-1767735173969
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/lino-env/issues/24
+Your prepared branch: issue-24-e5cb18c72ce6
+Your prepared working directory: /tmp/gh-issue-solver-1767735173969
+
+Proceed.

--- a/docs/case-studies/issue-24/README.md
+++ b/docs/case-studies/issue-24/README.md
@@ -1,0 +1,25 @@
+# Case Study: Issue #24 - Manual Release of Rust Package Didn't Work
+
+## Quick Summary
+
+**Problem:** Manual release of the Rust package via `workflow_dispatch` was being skipped instead of executing.
+
+**Root Cause:** GitHub Actions job dependency chain issue - when a job with `needs: [other-job]` has its dependency skipped, the dependent job is also skipped, even if its own `if` condition would evaluate to true.
+
+**Solution:** Added `always() && !cancelled()` to job conditions and implemented full parity with JavaScript workflow (instant and changelog-pr modes).
+
+## Files in This Case Study
+
+- [analysis.md](./analysis.md) - Detailed root cause analysis and solution documentation
+- [github-actions-research.md](./github-actions-research.md) - Research findings from online sources
+
+## Key Takeaways
+
+1. **GitHub Actions `needs` behavior is subtle** - When a dependency is skipped, dependent jobs don't even evaluate their `if` condition
+2. **Use `always()` to force condition evaluation** - This ensures the `if` condition is evaluated even when dependencies are skipped
+3. **Use `!cancelled()` for safety** - Prevents jobs from running if the workflow was cancelled
+4. **Check `needs.job.result` explicitly** - Ensure dependent jobs actually succeeded before proceeding
+
+## Related Issues
+
+- [GitHub Actions Runner Issue #491](https://github.com/actions/runner/issues/491) - Job-level "if" condition not evaluated correctly if job in "needs" property is skipped

--- a/docs/case-studies/issue-24/analysis.md
+++ b/docs/case-studies/issue-24/analysis.md
@@ -1,0 +1,203 @@
+# Case Study: Issue #24 - Manual Release of Rust Package Didn't Work
+
+## Issue Summary
+
+When using `workflow_dispatch` to trigger a manual release of the Rust package, the release job was skipped instead of executing the version bump and crates.io publishing steps.
+
+## Timeline of Events
+
+### 2026-01-06 21:28:18 UTC - Manual Workflow Dispatch Triggered
+
+- **Run ID:** 20762641678
+- **Event:** `workflow_dispatch`
+- **Trigger:** User manually triggered the Rust CI/CD Pipeline with bump_type option
+
+### Workflow Execution Results
+
+| Job | Status | Duration | Notes |
+|-----|--------|----------|-------|
+| Detect Changes | Skipped | 0s | Expected - job has `if: github.event_name != 'workflow_dispatch'` |
+| Lint and Format Check | Skipped | 0s | **BUG** - Should have run but skipped due to dependency issue |
+| Test (ubuntu-latest) | Success | 16s | Ran correctly with `always()` condition |
+| Test (macos-latest) | Success | 19s | Ran correctly with `always()` condition |
+| Test (windows-latest) | Success | 36s | Ran correctly with `always()` condition |
+| Changelog Fragment Check | Skipped | 0s | Expected - only runs on PRs |
+| Build Package | Skipped | 0s | **BUG** - Required lint to succeed, but lint was skipped |
+| Auto Release | Skipped | 0s | Expected - only runs on push to main |
+| Manual Release | Skipped | 0s | **BUG** - Never ran because build was skipped |
+
+## Root Cause Analysis
+
+### The Core Issue
+
+The `lint` job depends on `detect-changes`, but `detect-changes` is skipped during `workflow_dispatch`. When a GitHub Actions job's dependency is skipped, the dependent job is also skipped by default, regardless of its own `if` condition.
+
+### Dependency Chain Breakdown
+
+```
+detect-changes (skipped on workflow_dispatch)
+       |
+       v
+     lint (skipped because dependency was skipped)
+       |
+       v
+     build (skipped because lint.result != 'success')
+       |
+       v
+manual-release (never runs because build was skipped)
+```
+
+### Relevant Code Locations
+
+**1. detect-changes job (rust.yml:47-75)**
+```yaml
+detect-changes:
+  name: Detect Changes
+  runs-on: ubuntu-latest
+  if: github.event_name != 'workflow_dispatch'  # Intentionally skipped
+```
+
+**2. lint job (rust.yml:112-155)**
+```yaml
+lint:
+  name: Lint and Format Check
+  runs-on: ubuntu-latest
+  needs: [detect-changes]  # PROBLEM: Depends on skipped job
+  if: |
+    github.event_name == 'push' ||
+    github.event_name == 'workflow_dispatch' ||  # This condition is never evaluated!
+    ...
+```
+
+**3. build job (rust.yml:190-217)**
+```yaml
+build:
+  name: Build Package
+  runs-on: ubuntu-latest
+  needs: [lint, test]
+  if: always() && needs.lint.result == 'success' && needs.test.result == 'success'
+  # When lint is skipped, needs.lint.result == 'skipped', not 'success'
+```
+
+**4. manual-release job (rust.yml:340-437)**
+```yaml
+manual-release:
+  name: Manual Release
+  needs: [lint, test, build]  # All three must succeed
+  if: github.event_name == 'workflow_dispatch'
+```
+
+### Why Test Jobs Ran Successfully
+
+The `test` job has a different pattern:
+```yaml
+test:
+  needs: [detect-changes, changelog]
+  if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || ...)
+```
+
+The `always()` function ensures the job's `if` condition is evaluated even when dependencies are skipped.
+
+## Comparison with JavaScript Workflow
+
+The JavaScript workflow (`js.yml`) handles manual releases differently:
+
+```yaml
+instant-release:
+  name: Instant Release
+  if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant'
+  runs-on: ubuntu-latest
+  # NO 'needs' - completely independent!
+```
+
+Key differences:
+1. **No dependencies on CI jobs** - The `instant-release` job runs independently
+2. **Two release modes** - Users can choose between "instant" (direct release) and "changeset-pr" (create PR for review)
+3. **Self-contained steps** - All setup (Node.js, dependencies) is done within the job
+
+## Proposed Solutions
+
+### Solution 1: Add `always()` to lint job and update build condition (Minimal Fix)
+
+```yaml
+lint:
+  name: Lint and Format Check
+  runs-on: ubuntu-latest
+  needs: [detect-changes]
+  if: |
+    always() && (
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.rs-changed == 'true' ||
+      ...
+    )
+```
+
+And update `build` to handle skipped lint on workflow_dispatch:
+```yaml
+build:
+  if: |
+    always() && (
+      (github.event_name == 'workflow_dispatch' && needs.test.result == 'success') ||
+      (needs.lint.result == 'success' && needs.test.result == 'success')
+    )
+```
+
+### Solution 2: Independent Manual Release Job (Match JavaScript Pattern)
+
+Create a completely independent `manual-release` job that includes its own lint, test, and build steps - similar to the JavaScript `instant-release` job.
+
+### Solution 3: Add Release Mode Options (Full JavaScript Parity)
+
+Add `release_mode` input with options:
+- `instant`: Direct release (includes lint/test/build in same job)
+- `changeset-pr`: Creates a PR with changelog fragment for review
+
+## Recommendation
+
+**Combined Solution (Solution 1 + Solution 3)** was implemented:
+1. Add `always() && !cancelled()` to job conditions to fix the skipped job issue
+2. Add `release_mode` input with "instant" and "changelog-pr" options for full JavaScript parity
+
+## Implementation Details
+
+### Changes Made to `.github/workflows/rust.yml`
+
+1. **Added `release_mode` workflow input** (lines 18-26):
+   - `instant`: Direct release (includes lint/test/build verification)
+   - `changelog-pr`: Creates a PR with changelog fragment for review
+
+2. **Fixed `lint` job condition** (lines 116-128):
+   - Added `always() && !cancelled()` to ensure the job runs even when `detect-changes` is skipped
+   - Added comment explaining why `always()` is required
+
+3. **Updated `build` job condition** (line 200):
+   - Added `!cancelled()` for consistency
+
+4. **Updated `auto-release` job condition** (lines 229-233):
+   - Added `always() && !cancelled()` for consistent behavior
+   - Added explicit check for `needs.build.result == 'success'`
+
+5. **Renamed and updated `manual-release` job** (lines 357-461):
+   - Renamed to "Instant Release"
+   - Added `always() && !cancelled()` to condition
+   - Added check for `github.event.inputs.release_mode == 'instant'`
+   - Added check for `needs.build.result == 'success'`
+
+6. **Added new `changelog-pr` job** (lines 463-533):
+   - Creates a changelog fragment file
+   - Opens a pull request using `peter-evans/create-pull-request@v7`
+   - Matches the JavaScript workflow's `changeset-pr` pattern
+
+## Files Affected
+
+- `.github/workflows/rust.yml`
+- `docs/case-studies/issue-24/analysis.md` (this file)
+- `docs/case-studies/issue-24/github-actions-research.md`
+
+## Related Links
+
+- Issue: https://github.com/link-foundation/lino-env/issues/24
+- Failed Run: https://github.com/link-foundation/lino-env/actions/runs/20762641678
+- GitHub Actions Documentation: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds
+- GitHub Actions Runner Issue #491: https://github.com/actions/runner/issues/491

--- a/docs/case-studies/issue-24/github-actions-research.md
+++ b/docs/case-studies/issue-24/github-actions-research.md
@@ -1,0 +1,67 @@
+# GitHub Actions Research: Job Dependencies and Skipped Jobs
+
+## Key Findings from Online Research
+
+### The Core Behavior
+
+According to GitHub's documentation and community discussions, when a job in the `needs` dependency chain is skipped, all dependent jobs are also skipped unless they use a conditional expression that causes the job to continue.
+
+**GitHub Documentation Quote:**
+> "You can use the following status check functions as expressions in if conditionals. A default status check of success() is applied unless you include one of these functions."
+
+This means without explicitly using `always()`, `failure()`, or `cancelled()`, the implicit `success()` check will cause the job to skip when dependencies are skipped.
+
+### Known Issue
+
+This behavior is documented in [GitHub Actions Runner Issue #491](https://github.com/actions/runner/issues/491) - "Job-level 'if' condition not evaluated correctly if job in 'needs' property is skipped". The issue has been acknowledged by GitHub but is in their backlog with no timeline for resolution.
+
+### Recommended Workarounds
+
+1. **Use `!failure()` instead of `success()`**
+   - `if: "!failure()"` will run the job unless a dependency failed
+   - This allows the job to run when dependencies are skipped
+
+2. **Use `always()` with explicit conditions**
+   - `if: always() && (needs.a.result == 'success' || needs.a.result == 'skipped')`
+   - Forces evaluation of the `if` condition even when dependencies are skipped
+
+3. **Combine `always()` with result checks**
+   ```yaml
+   if: |
+     always() &&
+     needs.job_a.result == 'success' &&
+     (needs.job_b.result == 'success' || needs.job_b.result == 'skipped')
+   ```
+
+## Sources
+
+- [GitHub Community Discussion #45058 - success() returns false if dependent jobs are skipped](https://github.com/orgs/community/discussions/45058)
+- [GitHub Actions Runner Issue #2205 - Jobs skipped when NEEDS job ran successfully](https://github.com/actions/runner/issues/2205)
+- [GitHub Actions Runner Issue #491 - Job-level "if" condition not evaluated correctly](https://github.com/actions/runner/issues/491)
+- [GitHub Community Discussion #26945 - Jobs being skipped while using both needs and if](https://github.com/orgs/community/discussions/26945)
+- [GitHub Docs - Using conditions to control job execution](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution)
+- [GitHub Docs - Using jobs in a workflow](https://docs.github.com/actions/using-jobs/using-jobs-in-a-workflow)
+
+## Application to Issue #24
+
+The Rust workflow `lint` job has:
+```yaml
+needs: [detect-changes]
+if: |
+  github.event_name == 'push' ||
+  github.event_name == 'workflow_dispatch' ||
+  ...
+```
+
+When `detect-changes` is skipped (on `workflow_dispatch`), the `lint` job's `if` condition is never evaluated because the implicit `success()` check fails first.
+
+The fix is to add `always()` to force the `if` condition evaluation:
+```yaml
+needs: [detect-changes]
+if: |
+  always() && (
+    github.event_name == 'push' ||
+    github.event_name == 'workflow_dispatch' ||
+    ...
+  )
+```


### PR DESCRIPTION
## Summary

This PR fixes the issue where manual release of the Rust package via `workflow_dispatch` was being skipped instead of executing.

### Root Cause

When triggering the workflow via `workflow_dispatch`, the `detect-changes` job is intentionally skipped (it has `if: github.event_name != 'workflow_dispatch'`). However, the `lint` job has `needs: [detect-changes]`, and in GitHub Actions, when a job dependency is skipped, the dependent job is also skipped - even if its own `if` condition would evaluate to true.

This is a known GitHub Actions behavior documented in [GitHub Actions Runner Issue #491](https://github.com/actions/runner/issues/491).

### Solution

1. **Fix job conditions** - Added `always() && !cancelled()` to `lint`, `build`, `auto-release`, and `manual-release` job conditions to ensure they run properly when `detect-changes` is skipped

2. **Add release mode options** - Added `release_mode` workflow input with two options to match JavaScript workflow:
   - `instant` (default): Direct release that goes through lint/test/build verification
   - `changelog-pr`: Creates a pull request with a changelog fragment for review

3. **Add changelog-pr job** - New job that creates a changelog fragment and opens a PR using `peter-evans/create-pull-request@v7`

### Changes

- `.github/workflows/rust.yml` - Fixed job conditions and added new features
- `docs/case-studies/issue-24/` - Added case study documentation with:
  - Root cause analysis
  - Timeline of events
  - Online research findings
  - Implementation details

## Test Plan

- [ ] Verify that `workflow_dispatch` with `release_mode=instant` runs the full pipeline (lint → test → build → manual-release)
- [ ] Verify that `workflow_dispatch` with `release_mode=changelog-pr` creates a PR with changelog fragment
- [ ] Verify that normal push/PR workflows still work correctly
- [ ] Verify that auto-release still works on push to main

Fixes #24

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)