### PR TITLE
fix(rust): remove deprecated set-output GitHub Actions command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,13 +105,13 @@ jobs:
           SOURCE_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^rust/(src/|tests/|scripts/|Cargo\.toml)" | wc -l)
 
           if [ "$SOURCE_CHANGED" -gt 0 ] && [ "$FRAGMENTS" -eq 0 ]; then
-            echo "::warning::No changelog fragment found. Please add a changelog entry in rust/changelog.d/"
+            echo "::error::No changelog fragment found. Please add a changelog entry in rust/changelog.d/"
             echo ""
             echo "To create a changelog fragment:"
             echo "  Create a new .md file in rust/changelog.d/ with your changes"
             echo ""
             echo "See rust/changelog.d/README.md for more information."
-            exit 0
+            exit 1
           fi
 
           echo "Changelog check passed"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/lino-env/issues/26
+Your prepared branch: issue-26-059a356f2ae4
+Your prepared working directory: /tmp/gh-issue-solver-1767806206262
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/lino-env/issues/26
-Your prepared branch: issue-26-059a356f2ae4
-Your prepared working directory: /tmp/gh-issue-solver-1767806206262
-
-Proceed.

--- a/docs/case-studies/issue-26/README.md
+++ b/docs/case-studies/issue-26/README.md
@@ -1,0 +1,147 @@
+# Case Study: GitHub Actions `set-output` Deprecation Warnings
+
+## Issue Summary
+
+- **Issue**: [#26 - These warnings must be fixed in CI/CD](https://github.com/link-foundation/lino-env/issues/26)
+- **Type**: Bug
+- **Status**: Open
+- **Date Identified**: January 6, 2026
+
+## Problem Description
+
+The CI/CD pipeline generates 2 deprecation warnings during the "Instant Release" job:
+
+```
+The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.
+For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+```
+
+## Evidence
+
+### CI Run Details
+
+- **Run ID**: 20765751479
+- **Workflow**: Rust CI/CD Pipeline
+- **Job**: Instant Release
+- **Head SHA**: e13ac13b192e0a2476e3cc15d3ada3b3c23905bc
+- **Conclusion**: success (despite warnings)
+
+### Warning Location in Logs
+
+From `ci-logs/rust-20765751479.log` (lines 2510-2511):
+
+```
+Instant Release	UNKNOWN STEP	2026-01-06T23:51:14.1966757Z ##[warning]The `set-output` command is deprecated...
+Instant Release	UNKNOWN STEP	2026-01-06T23:51:14.1982195Z ##[warning]The `set-output` command is deprecated...
+```
+
+The warnings appear after:
+- "v0.1.1" version output
+- "Tag v0.1.1 already exists" message
+
+This indicates the warnings come from the `setOutput()` function calls in the version-and-commit.mjs script.
+
+## Root Cause Analysis
+
+### Source Code Location
+
+File: `rust/scripts/version-and-commit.mjs`, lines 58-65:
+
+```javascript
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  // Also log for visibility
+  console.log(`::set-output name=${key}::${value}`);  // <-- DEPRECATED
+}
+```
+
+### Technical Explanation
+
+The `setOutput` function does two things:
+1. **Correctly** writes to the `GITHUB_OUTPUT` environment file (new approach)
+2. **Also** outputs the deprecated `::set-output` command to stdout (old approach)
+
+While the new approach works correctly, the legacy stdout command is still being printed, causing GitHub Actions to emit deprecation warnings.
+
+### Why Two Warnings?
+
+Looking at the script, `setOutput` is called twice when a tag already exists:
+
+```javascript
+if (await checkTagExists(newVersion)) {
+  console.log(`Tag v${newVersion} already exists`);
+  setOutput('already_released', 'true');    // Warning #1
+  setOutput('new_version', newVersion);     // Warning #2
+  return;
+}
+```
+
+## Comparison with JS Version
+
+The JS version (`js/scripts/version-and-commit.mjs`, lines 103-108) is already correctly implemented:
+
+```javascript
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  // No deprecated command - correctly omitted!
+}
+```
+
+## Solution
+
+Remove the deprecated `console.log` line from the Rust version's `setOutput` function.
+
+### Before (deprecated)
+
+```javascript
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  // Also log for visibility
+  console.log(`::set-output name=${key}::${value}`);
+}
+```
+
+### After (fixed)
+
+```javascript
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+    console.log(`Output: ${key}=${value}`);  // Optional: plain log for visibility
+  }
+}
+```
+
+## Timeline of Events
+
+1. **October 11, 2022**: GitHub announces deprecation of `set-output` command
+2. **May 31, 2023**: Originally planned full disablement
+3. **July 24, 2023**: GitHub postpones removal due to significant usage
+4. **January 6, 2026**: Issue #26 reported with warnings still appearing
+
+## Related Resources
+
+- [GitHub Changelog: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
+- [GitHub Actions Environment Files documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files)
+
+## Impact Assessment
+
+- **Severity**: Low (warnings only, workflow still succeeds)
+- **Risk**: Medium (command may be disabled in future GitHub Actions updates)
+- **Files Affected**: 1 (`rust/scripts/version-and-commit.mjs`)
+
+## Lessons Learned
+
+1. When implementing both old and new approaches for compatibility, ensure the old approach is eventually removed
+2. Consistent patterns across language implementations (JS vs Rust scripts) help catch such discrepancies
+3. CI warnings should be treated as actionable items before they become errors

--- a/docs/case-studies/issue-26/analysis.md
+++ b/docs/case-studies/issue-26/analysis.md
@@ -1,0 +1,143 @@
+# Detailed Analysis: `set-output` Deprecation in Rust CI Pipeline
+
+## Affected Files
+
+### Primary Source
+
+| File | Line | Issue |
+|------|------|-------|
+| `rust/scripts/version-and-commit.mjs` | 64 | Uses deprecated `::set-output` command |
+
+### Comparison File
+
+| File | Status |
+|------|--------|
+| `js/scripts/version-and-commit.mjs` | Already correctly implemented (no deprecated command) |
+
+## Code Analysis
+
+### Rust Version - `setOutput` Function
+
+Location: `rust/scripts/version-and-commit.mjs:58-65`
+
+```javascript
+/**
+ * Append to GitHub Actions output file
+ * @param {string} key
+ * @param {string} value
+ */
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  // Also log for visibility
+  console.log(`::set-output name=${key}::${value}`);  // <-- LINE 64: DEPRECATED
+}
+```
+
+### JS Version - `setOutput` Function (Correct Implementation)
+
+Location: `js/scripts/version-and-commit.mjs:103-108`
+
+```javascript
+/**
+ * Append to GitHub Actions output file
+ * @param {string} key
+ * @param {string} value
+ */
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+}
+```
+
+## Call Sites Analysis
+
+The `setOutput` function is called in the following locations in the Rust version:
+
+### 1. When Tag Already Exists (lines 223-226)
+
+```javascript
+if (await checkTagExists(newVersion)) {
+  console.log(`Tag v${newVersion} already exists`);
+  setOutput('already_released', 'true');    // Call #1
+  setOutput('new_version', newVersion);     // Call #2
+  return;
+}
+```
+
+### 2. When No Changes to Commit (lines 242-244)
+
+```javascript
+console.log('No changes to commit');
+setOutput('version_committed', 'false');
+setOutput('new_version', newVersion);
+```
+
+### 3. After Successful Push (lines 268-269)
+
+```javascript
+setOutput('version_committed', 'true');
+setOutput('new_version', newVersion);
+```
+
+## CI Log Evidence
+
+From `ci-logs/rust-20765751479.log`:
+
+```
+2508: Instant Release	UNKNOWN STEP	2026-01-06T23:51:14.1937150Z v0.1.1
+2509: Instant Release	UNKNOWN STEP	2026-01-06T23:51:14.1945280Z Tag v0.1.1 already exists
+2510: Instant Release	UNKNOWN STEP	##[warning]The `set-output` command is deprecated...
+2511: Instant Release	UNKNOWN STEP	##[warning]The `set-output` command is deprecated...
+2512: Instant Release	UNKNOWN STEP	##[group]Run cargo build --release
+```
+
+The warnings appear immediately after "Tag v0.1.1 already exists", confirming the issue is in the "tag already exists" code path (Call #1 and Call #2).
+
+## Proposed Fix
+
+### Option 1: Remove Deprecated Line (Minimal Change)
+
+```javascript
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+}
+```
+
+### Option 2: Add Plain Log for Visibility (Recommended)
+
+```javascript
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+    console.log(`Output: ${key}=${value}`);
+  }
+}
+```
+
+## Recommendation
+
+Use **Option 2** to maintain visibility of what outputs are being set during workflow execution, which helps with debugging.
+
+## Testing Strategy
+
+1. Create a test script that simulates the `setOutput` function
+2. Verify it writes to GITHUB_OUTPUT correctly
+3. Ensure no `::set-output` appears in stdout
+4. Run the actual workflow and verify no warnings appear
+
+## Risk Assessment
+
+| Factor | Assessment |
+|--------|------------|
+| Breaking Changes | None - output mechanism unchanged |
+| Backwards Compatibility | Maintained - GITHUB_OUTPUT approach already implemented |
+| Test Coverage | Manual CI run verification required |

--- a/docs/case-studies/issue-26/github-actions-research.md
+++ b/docs/case-studies/issue-26/github-actions-research.md
@@ -1,0 +1,103 @@
+# GitHub Actions `set-output` Deprecation Research
+
+## Official Announcement
+
+Source: [GitHub Blog Changelog - October 11, 2022](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
+
+## What's Being Deprecated
+
+GitHub deprecated two workflow commands that are executed via stdout:
+- `::save-state name={name}::{value}` - for saving state between workflow steps
+- `::set-output name={name}::{value}` - for setting output values accessible by subsequent steps
+
+## Replacement Solution
+
+The new approach uses environment files instead of stdout commands:
+
+### Old Approach (Deprecated)
+
+```bash
+# Setting output
+echo "::set-output name=myOutput::myValue"
+
+# Saving state
+echo "::save-state name=myState::myValue"
+```
+
+### New Approach (Recommended)
+
+```bash
+# Setting output
+echo "myOutput=myValue" >> $GITHUB_OUTPUT
+
+# Saving state
+echo "myState=myValue" >> $GITHUB_STATE
+```
+
+### JavaScript/Node.js Implementation
+
+**Old approach:**
+```javascript
+console.log(`::set-output name=${key}::${value}`);
+```
+
+**New approach:**
+```javascript
+const fs = require('fs');
+const outputFile = process.env.GITHUB_OUTPUT;
+if (outputFile) {
+  fs.appendFileSync(outputFile, `${key}=${value}\n`);
+}
+```
+
+## Deprecation Timeline
+
+| Date | Event |
+|------|-------|
+| October 11, 2022 | Initial deprecation announcement |
+| May 31, 2023 | Originally planned full disablement |
+| June 1, 2023 | Originally planned failure date for deprecated commands |
+| July 24, 2023 | GitHub postponed removal due to "significant usage of these commands" |
+| Present | Warnings shown but commands still functional |
+
+## Requirements for Upgrade
+
+1. **Action Authors**: Update `@actions/core` to v1.10.0 or later
+2. **Self-hosted Runners**: Update to version 2.297.0 or greater
+
+## Handling Multi-line Values
+
+For multi-line values, use delimiters:
+
+```bash
+{name}<<{delimiter}
+{value}
+{delimiter}
+```
+
+Example:
+```bash
+echo "JSON_RESPONSE<<EOF" >> $GITHUB_OUTPUT
+echo "$response_json" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
+```
+
+## Why This Change?
+
+The stdout-based commands were deprecated because:
+1. **Security**: Environment files provide better isolation
+2. **Reliability**: Reduces parsing issues with special characters
+3. **Performance**: Avoids stdout parsing overhead
+
+## Verification
+
+To verify the fix works correctly:
+1. Run a workflow that sets outputs
+2. Check that no deprecation warnings appear in the logs
+3. Verify that subsequent steps can still access the output values
+
+## References
+
+- [GitHub Blog Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
+- [GitHub Actions Workflow Commands Documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)
+- [Environment Files Documentation](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files)

--- a/experiments/test-setOutput.mjs
+++ b/experiments/test-setOutput.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+ * Test script to verify setOutput function behavior
+ *
+ * This script tests that:
+ * 1. When GITHUB_OUTPUT is set, it writes to the file
+ * 2. When GITHUB_OUTPUT is set, it logs the output
+ * 3. When GITHUB_OUTPUT is not set, nothing happens (graceful no-op)
+ * 4. No deprecated ::set-output command is emitted
+ */
+
+import { appendFileSync, readFileSync, unlinkSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Append to GitHub Actions output file
+ * @param {string} key
+ * @param {string} value
+ */
+function setOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+    console.log(`Output: ${key}=${value}`);
+  }
+}
+
+// Test 1: Without GITHUB_OUTPUT set
+console.log('=== Test 1: Without GITHUB_OUTPUT ===');
+delete process.env.GITHUB_OUTPUT;
+console.log('Calling setOutput without GITHUB_OUTPUT...');
+setOutput('test_key', 'test_value');
+console.log('No error = PASS (graceful no-op)\n');
+
+// Test 2: With GITHUB_OUTPUT set
+console.log('=== Test 2: With GITHUB_OUTPUT ===');
+const testOutputFile = join(tmpdir(), `github_output_test_${Date.now()}.txt`);
+process.env.GITHUB_OUTPUT = testOutputFile;
+
+console.log(`GITHUB_OUTPUT set to: ${testOutputFile}`);
+console.log('Calling setOutput...');
+setOutput('version_committed', 'true');
+setOutput('new_version', '1.0.0');
+
+// Verify file contents
+const fileContents = readFileSync(testOutputFile, 'utf-8');
+console.log('\nFile contents:');
+console.log(fileContents);
+
+// Check expected contents
+const expectedLines = [
+  'version_committed=true',
+  'new_version=1.0.0'
+];
+
+let allPassed = true;
+for (const line of expectedLines) {
+  if (!fileContents.includes(line)) {
+    console.error(`FAIL: Missing expected line: ${line}`);
+    allPassed = false;
+  }
+}
+
+// Check no deprecated command
+if (fileContents.includes('::set-output')) {
+  console.error('FAIL: Found deprecated ::set-output in output');
+  allPassed = false;
+}
+
+// Cleanup
+unlinkSync(testOutputFile);
+
+if (allPassed) {
+  console.log('\nAll tests PASSED!');
+  process.exit(0);
+} else {
+  console.log('\nSome tests FAILED!');
+  process.exit(1);
+}

--- a/rust/changelog.d/20260107_184452_fix_ci_deprecation_warnings.md
+++ b/rust/changelog.d/20260107_184452_fix_ci_deprecation_warnings.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Remove deprecated `set-output` GitHub Actions command from `scripts/version-and-commit.mjs`
+- Change changelog fragment check from warning to error to enforce changelog entries for source code changes

--- a/rust/scripts/version-and-commit.mjs
+++ b/rust/scripts/version-and-commit.mjs
@@ -59,9 +59,8 @@ function setOutput(key, value) {
   const outputFile = process.env.GITHUB_OUTPUT;
   if (outputFile) {
     appendFileSync(outputFile, `${key}=${value}\n`);
+    console.log(`Output: ${key}=${value}`);
   }
-  // Also log for visibility
-  console.log(`::set-output name=${key}::${value}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the deprecation warnings in CI/CD and enforces changelog fragment requirements.

### Problem

1. **Set-output deprecation**: The CI/CD pipeline was generating 2 deprecation warnings during the "Instant Release" job:
   ```
   The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.
   ```

2. **Changelog check too lenient**: The changelog fragment check only produced a warning when source code changed without a changelog entry, allowing PRs to pass without proper documentation.

### Solutions

#### Fix 1: Remove deprecated `set-output` command

**Root Cause**: The `setOutput` function in `rust/scripts/version-and-commit.mjs` was using both:
1. The new `GITHUB_OUTPUT` environment file approach (correct)
2. The deprecated `::set-output` stdout command (causes warnings)

**Solution**: Removed the deprecated `console.log(`::set-output name=${key}::${value}`)` line and replaced it with a plain `console.log(`Output: ${key}=${value}`)` for visibility.

#### Fix 2: Enforce changelog fragment requirement

**Root Cause**: The changelog fragment check in `.github/workflows/rust.yml` used `::warning::` and `exit 0`, so it would only warn but still pass CI even when source code changed without a changelog entry.

**Solution**: Changed `::warning::` to `::error::` and `exit 0` to `exit 1` so that CI fails when Rust source code (`src/`, `tests/`, `scripts/`, `Cargo.toml`) is changed without a changelog fragment.

### Changes

- `rust/scripts/version-and-commit.mjs`: Remove deprecated `set-output` command
- `.github/workflows/rust.yml`: Enforce changelog fragment requirement as error instead of warning
- `rust/changelog.d/`: Add changelog fragment for this PR
- `docs/case-studies/issue-26/`: Add case study documentation with CI logs and analysis
- `experiments/test-setOutput.mjs`: Add test script to verify the fix

### Test Plan

- [x] Verified the set-output fix works correctly with a local test script
- [x] Confirmed no other files use the deprecated `::set-output` command
- [x] Compared with the JS version (`js/scripts/version-and-commit.mjs`) which was already correctly implemented
- [x] Added changelog fragment so the enforced check will pass

### References

- [GitHub Changelog: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- [PR Comment requesting changelog enforcement](https://github.com/link-foundation/lino-env/pull/27#issuecomment-3720001474)

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)