### PR TITLE
feat!: drop support for multiple values of the same variable name

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-28T19:40:57.697Z for PR creation at branch issue-28-e8d6f457fe94 for issue https://github.com/link-foundation/lino-env/issues/28

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-28T19:40:57.697Z for PR creation at branch issue-28-e8d6f457fe94 for issue https://github.com/link-foundation/lino-env/issues/28

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lino-env
 
-A library to operate .lenv files - an alternative to .env files that uses `: ` (colon-space) instead of `=` for key-value separation and supports duplicate keys.
+A library to operate .lenv files - an alternative to .env files that uses `: ` (colon-space) instead of `=` for key-value separation.
 
 **Available in both JavaScript and Rust!**
 
@@ -18,7 +18,7 @@ GITHUB_TOKEN: gh_...
 API_KEY: abc123
 ```
 
-The key difference is the use of `: ` separator, which aligns with [links-notation](https://github.com/link-foundation/links-notation) format. Additionally, .lenv files support duplicate keys, where multiple instances of the same key can exist.
+The key difference is the use of `: ` separator, which aligns with [links-notation](https://github.com/link-foundation/links-notation) format. If a key appears multiple times, the last value wins (rewrite semantics).
 
 ## Packages
 
@@ -106,7 +106,7 @@ For full API documentation, see the [Rust README](./rust/README.md).
 - Key-value separator: `: ` (colon followed by space)
 - One key-value pair per line
 - Empty lines and lines starting with `#` are ignored
-- Duplicate keys are allowed
+- If a key appears multiple times, the last value wins (rewrite semantics)
 - Values can contain spaces, colons, and other special characters
 
 Example `.lenv` file:
@@ -115,10 +115,6 @@ Example `.lenv` file:
 # Configuration file
 GITHUB_TOKEN: gh_abc123xyz
 TELEGRAM_TOKEN: 054test456
-
-# Multiple servers
-SERVER: server1.example.com
-SERVER: server2.example.com
 
 # Values with special characters
 URL: https://example.com:8080

--- a/js/.changeset/drop-duplicate-keys.md
+++ b/js/.changeset/drop-duplicate-keys.md
@@ -1,0 +1,5 @@
+---
+'lino-env': major
+---
+
+Drop support for multiple values of the same variable name. Duplicate keys now use last-value-wins (rewrite semantics). Removed `getAll()` and `add()` methods. Internal data structure changed from `Map<string, string[]>` to `Map<string, string>`.

--- a/js/README.md
+++ b/js/README.md
@@ -1,6 +1,6 @@
 # lino-env (JavaScript)
 
-A JavaScript library to operate .lenv files - an alternative to .env files that uses `: ` (colon-space) instead of `=` for key-value separation and supports duplicate keys.
+A JavaScript library to operate .lenv files - an alternative to .env files that uses `: ` (colon-space) instead of `=` for key-value separation.
 
 ## What are .lenv files?
 
@@ -16,7 +16,7 @@ GITHUB_TOKEN: gh_...
 API_KEY: abc123
 ```
 
-The key difference is the use of `: ` separator, which aligns with [links-notation](https://github.com/link-foundation/links-notation) format. Additionally, .lenv files support duplicate keys, where multiple instances of the same key can exist.
+The key difference is the use of `: ` separator, which aligns with [links-notation](https://github.com/link-foundation/links-notation) format. If a key appears multiple times, the last value wins (rewrite semantics).
 
 ## Installation
 
@@ -127,7 +127,7 @@ const env = new LinoEnv('.lenv');
 
 ##### `read()`
 
-Reads and parses the .lenv file. If the file doesn't exist, initializes with empty data.
+Reads and parses the .lenv file. If the file doesn't exist, initializes with empty data. If a key appears multiple times, the last value wins.
 
 ```javascript
 const env = new LinoEnv('.lenv');
@@ -148,45 +148,21 @@ Returns: `this` (for method chaining)
 
 ##### `get(reference)`
 
-Gets the last instance of a reference (key).
+Gets the value of a reference (key).
 
 ```javascript
-env.add('API_KEY', 'value1');
-env.add('API_KEY', 'value2');
-console.log(env.get('API_KEY')); // 'value2'
+env.set('API_KEY', 'value');
+console.log(env.get('API_KEY')); // 'value'
 ```
 
 Returns: `string | undefined`
 
-##### `getAll(reference)`
-
-Gets all instances of a reference (key).
-
-```javascript
-env.add('API_KEY', 'value1');
-env.add('API_KEY', 'value2');
-console.log(env.getAll('API_KEY')); // ['value1', 'value2']
-```
-
-Returns: `string[]`
-
 ##### `set(reference, value)`
 
-Sets a reference to a single value, replacing all existing instances.
+Sets a reference to a value. If the key already exists, the value is overwritten.
 
 ```javascript
 env.set('API_KEY', 'new_value');
-```
-
-Returns: `this` (for method chaining)
-
-##### `add(reference, value)`
-
-Adds a new instance of a reference, allowing duplicates.
-
-```javascript
-env.add('API_KEY', 'value1');
-env.add('API_KEY', 'value2'); // Now there are 2 instances
 ```
 
 Returns: `this` (for method chaining)
@@ -205,7 +181,7 @@ Returns: `boolean`
 
 ##### `delete(reference)`
 
-Deletes all instances of a reference.
+Deletes a reference.
 
 ```javascript
 env.delete('API_KEY');
@@ -225,15 +201,14 @@ Returns: `string[]`
 
 ##### `toObject()`
 
-Converts to a plain object with the last instance of each key.
+Converts to a plain object.
 
 ```javascript
-env.add('KEY1', 'value1a');
-env.add('KEY1', 'value1b');
+env.set('KEY1', 'value1');
 env.set('KEY2', 'value2');
 
 console.log(env.toObject());
-// { KEY1: 'value1b', KEY2: 'value2' }
+// { KEY1: 'value1', KEY2: 'value2' }
 ```
 
 Returns: `Object`
@@ -275,7 +250,7 @@ Returns: `LinoEnv`
 - Key-value separator: `: ` (colon followed by space)
 - One key-value pair per line
 - Empty lines and lines starting with `#` are ignored
-- Duplicate keys are allowed
+- If a key appears multiple times, the last value wins (rewrite semantics)
 - Values can contain spaces, colons, and other special characters
 
 Example `.lenv` file:
@@ -284,10 +259,6 @@ Example `.lenv` file:
 # Configuration file
 GITHUB_TOKEN: gh_abc123xyz
 TELEGRAM_TOKEN: 054test456
-
-# Multiple servers
-SERVER: server1.example.com
-SERVER: server2.example.com
 
 # Values with special characters
 URL: https://example.com:8080

--- a/js/src/lino-env.mjs
+++ b/js/src/lino-env.mjs
@@ -13,7 +13,7 @@ export class LinoEnv {
 
   /**
    * Read and parse the .lenv file
-   * Stores all instances of each key (duplicates are allowed)
+   * If a key appears multiple times, the last value wins (rewrite semantics)
    */
   read() {
     try {
@@ -36,11 +36,8 @@ export class LinoEnv {
         const key = line.substring(0, separatorIndex).trim();
         const value = line.substring(separatorIndex + 2); // Don't trim the value to preserve spaces
 
-        // Store all instances of the key
-        if (!this.data.has(key)) {
-          this.data.set(key, []);
-        }
-        this.data.get(key).push(value);
+        // Last value wins (rewrite semantics)
+        this.data.set(key, value);
       }
 
       return this;
@@ -52,48 +49,21 @@ export class LinoEnv {
   }
 
   /**
-   * Get the last instance of a reference (key)
+   * Get the value of a reference (key)
    * @param {string} reference - The key to look up
-   * @returns {string|undefined} The last value associated with the key
+   * @returns {string|undefined} The value associated with the key
    */
   get(reference) {
-    const values = this.data.get(reference);
-    if (!values || values.length === 0) {
-      return undefined;
-    }
-    return values[values.length - 1]; // Return last instance
+    return this.data.get(reference);
   }
 
   /**
-   * Get all instances of a reference (key)
-   * @param {string} reference - The key to look up
-   * @returns {string[]} All values associated with the key
-   */
-  getAll(reference) {
-    return this.data.get(reference) || [];
-  }
-
-  /**
-   * Set all instances of a reference to a new value
-   * Replaces all existing instances with a single new value
+   * Set a reference to a value
    * @param {string} reference - The key to set
    * @param {string} value - The new value
    */
   set(reference, value) {
-    this.data.set(reference, [value]);
-    return this;
-  }
-
-  /**
-   * Add a new instance of a reference (allows duplicates)
-   * @param {string} reference - The key to add
-   * @param {string} value - The value to add
-   */
-  add(reference, value) {
-    if (!this.data.has(reference)) {
-      this.data.set(reference, []);
-    }
-    this.data.get(reference).push(value);
+    this.data.set(reference, value);
     return this;
   }
 
@@ -103,10 +73,8 @@ export class LinoEnv {
   write() {
     const lines = [];
 
-    for (const [key, values] of this.data.entries()) {
-      for (const value of values) {
-        lines.push(`${key}: ${value}`);
-      }
+    for (const [key, value] of this.data.entries()) {
+      lines.push(`${key}: ${value}`);
     }
 
     writeFileSync(this.filePath, `${lines.join('\n')}\n`, 'utf-8');
@@ -119,11 +87,11 @@ export class LinoEnv {
    * @returns {boolean}
    */
   has(reference) {
-    return this.data.has(reference) && this.data.get(reference).length > 0;
+    return this.data.has(reference);
   }
 
   /**
-   * Delete all instances of a reference
+   * Delete a reference
    * @param {string} reference - The key to delete
    */
   delete(reference) {
@@ -140,13 +108,13 @@ export class LinoEnv {
   }
 
   /**
-   * Get all entries as an object (with last instance of each key)
+   * Get all entries as an object
    * @returns {Object}
    */
   toObject() {
     const obj = {};
-    for (const [key, values] of this.data.entries()) {
-      obj[key] = values[values.length - 1]; // Use last instance
+    for (const [key, value] of this.data.entries()) {
+      obj[key] = value;
     }
     return obj;
   }

--- a/js/tests/lino-env.test.mjs
+++ b/js/tests/lino-env.test.mjs
@@ -1,6 +1,6 @@
 import { test, assert } from 'test-anywhere';
 import { LinoEnv, readLinoEnv, writeLinoEnv } from '../src/lino-env.mjs';
-import { unlinkSync, existsSync } from 'node:fs';
+import { unlinkSync, existsSync, writeFileSync } from 'node:fs';
 
 const TEST_FILE = '.test.lenv';
 
@@ -40,17 +40,6 @@ test('should read a .lenv file', () => {
 });
 
 // get() method
-test('should get the last instance of a reference', () => {
-  cleanup();
-  const env = new LinoEnv(TEST_FILE);
-  env.add('API_KEY', 'value1');
-  env.add('API_KEY', 'value2');
-  env.add('API_KEY', 'value3');
-
-  assert.equal(env.get('API_KEY'), 'value3');
-  cleanup();
-});
-
 test('should return undefined for non-existent reference', () => {
   cleanup();
   const env = new LinoEnv(TEST_FILE);
@@ -58,48 +47,36 @@ test('should return undefined for non-existent reference', () => {
   cleanup();
 });
 
-// getAll() method
-test('should get all instances of a reference', () => {
-  cleanup();
-  const env = new LinoEnv(TEST_FILE);
-  env.add('API_KEY', 'value1');
-  env.add('API_KEY', 'value2');
-  env.add('API_KEY', 'value3');
-
-  const all = env.getAll('API_KEY');
-  assert.deepEqual(all, ['value1', 'value2', 'value3']);
-  cleanup();
-});
-
-test('should return empty array for non-existent reference', () => {
-  cleanup();
-  const env = new LinoEnv(TEST_FILE);
-  assert.deepEqual(env.getAll('NON_EXISTENT'), []);
-  cleanup();
-});
-
 // set() method
-test('should set all instances of a reference to a new value', () => {
+test('should set a reference to a value', () => {
   cleanup();
   const env = new LinoEnv(TEST_FILE);
-  env.add('API_KEY', 'value1');
-  env.add('API_KEY', 'value2');
   env.set('API_KEY', 'new_value');
 
   assert.equal(env.get('API_KEY'), 'new_value');
-  assert.deepEqual(env.getAll('API_KEY'), ['new_value']);
   cleanup();
 });
 
-// add() method
-test('should add duplicate instances', () => {
+// Duplicate keys: last value wins (rewrite semantics)
+test('should use last value when duplicate keys exist in file', () => {
+  cleanup();
+  // Write a file with duplicate keys manually
+  writeFileSync(TEST_FILE, 'A: value1\nA: value2\n', 'utf-8');
+
+  const env = new LinoEnv(TEST_FILE);
+  env.read();
+
+  assert.equal(env.get('A'), 'value2');
+  cleanup();
+});
+
+test('should overwrite when setting same key twice', () => {
   cleanup();
   const env = new LinoEnv(TEST_FILE);
-  env.add('KEY', 'value1');
-  env.add('KEY', 'value2');
-  env.add('KEY', 'value3');
+  env.set('KEY', 'value1');
+  env.set('KEY', 'value2');
 
-  assert.deepEqual(env.getAll('KEY'), ['value1', 'value2', 'value3']);
+  assert.equal(env.get('KEY'), 'value2');
   cleanup();
 });
 
@@ -121,11 +98,10 @@ test('should return false for non-existent reference', () => {
 });
 
 // delete() method
-test('should delete all instances of a reference', () => {
+test('should delete a reference', () => {
   cleanup();
   const env = new LinoEnv(TEST_FILE);
-  env.add('KEY', 'value1');
-  env.add('KEY', 'value2');
+  env.set('KEY', 'value1');
   env.delete('KEY');
 
   assert.equal(env.has('KEY'), false);
@@ -150,35 +126,31 @@ test('should return all keys', () => {
 });
 
 // toObject() method
-test('should convert to object with last instance of each key', () => {
+test('should convert to object', () => {
   cleanup();
   const env = new LinoEnv(TEST_FILE);
-  env.add('KEY1', 'value1a');
-  env.add('KEY1', 'value1b');
+  env.set('KEY1', 'value1');
   env.set('KEY2', 'value2');
 
   const obj = env.toObject();
   assert.deepEqual(obj, {
-    KEY1: 'value1b',
+    KEY1: 'value1',
     KEY2: 'value2',
   });
   cleanup();
 });
 
 // Persistence
-test('should persist duplicates across write/read', () => {
+test('should persist values across write/read', () => {
   cleanup();
   const env1 = new LinoEnv(TEST_FILE);
-  env1.add('KEY', 'value1');
-  env1.add('KEY', 'value2');
-  env1.add('KEY', 'value3');
+  env1.set('KEY', 'value');
   env1.write();
 
   const env2 = new LinoEnv(TEST_FILE);
   env2.read();
 
-  assert.deepEqual(env2.getAll('KEY'), ['value1', 'value2', 'value3']);
-  assert.equal(env2.get('KEY'), 'value3');
+  assert.equal(env2.get('KEY'), 'value');
   cleanup();
 });
 
@@ -277,5 +249,20 @@ test('should handle empty values', () => {
 
   const env2 = readLinoEnv(TEST_FILE);
   assert.equal(env2.get('EMPTY_KEY'), '');
+  cleanup();
+});
+
+// Write does not produce duplicate lines
+test('should write one line per key', () => {
+  cleanup();
+  const env = new LinoEnv(TEST_FILE);
+  env.set('KEY', 'value1');
+  env.set('KEY', 'value2');
+  env.write();
+
+  const env2 = new LinoEnv(TEST_FILE);
+  env2.read();
+  assert.equal(env2.get('KEY'), 'value2');
+  assert.equal(env2.keys().length, 1);
   cleanup();
 });

--- a/rust/README.md
+++ b/rust/README.md
@@ -6,6 +6,8 @@ A Rust library to read and write `.lenv` files.
 
 `.lenv` files are environment configuration files that use `: ` (colon-space) instead of `=` for key-value separation. This format is part of the links-notation specification.
 
+If a key appears multiple times, the last value wins (rewrite semantics).
+
 Example `.lenv` file:
 
 ```
@@ -20,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lino-env = "0.1"
+lino-env = "0.2"
 ```
 
 ## Usage
@@ -46,28 +48,6 @@ if let Some(token) = env.get("GITHUB_TOKEN") {
 }
 ```
 
-### Multiple Values per Key
-
-`.lenv` files support multiple values for the same key:
-
-```rust
-use lino_env::LinoEnv;
-
-let mut env = LinoEnv::new(".lenv");
-
-// Add multiple values for the same key
-env.add("ALLOWED_HOST", "localhost");
-env.add("ALLOWED_HOST", "example.com");
-env.add("ALLOWED_HOST", "api.example.com");
-
-// Get the last value
-assert_eq!(env.get("ALLOWED_HOST"), Some("api.example.com".to_string()));
-
-// Get all values
-let hosts = env.get_all("ALLOWED_HOST");
-assert_eq!(hosts, vec!["localhost", "example.com", "api.example.com"]);
-```
-
 ### Convenience Functions
 
 ```rust
@@ -90,16 +70,14 @@ println!("{:?}", env.get("KEY1"));
 ### LinoEnv
 
 - `new(file_path)` - Create a new LinoEnv instance
-- `read()` - Read and parse the .lenv file
+- `read()` - Read and parse the .lenv file (last value wins for duplicate keys)
 - `write()` - Write the current data to the file
-- `get(key)` - Get the last value for a key
-- `get_all(key)` - Get all values for a key
-- `set(key, value)` - Set a key to a single value (replaces all)
-- `add(key, value)` - Add a value to a key (allows duplicates)
+- `get(key)` - Get the value for a key
+- `set(key, value)` - Set a key to a value (overwrites if exists)
 - `has(key)` - Check if a key exists
-- `delete(key)` - Delete all values for a key
+- `delete(key)` - Delete a key
 - `keys()` - Get all keys
-- `to_hash_map()` - Convert to HashMap with last values
+- `to_hash_map()` - Convert to HashMap
 
 ## License
 

--- a/rust/changelog.d/20260328_000000_drop_duplicate_keys.md
+++ b/rust/changelog.d/20260328_000000_drop_duplicate_keys.md
@@ -1,0 +1,13 @@
+---
+bump: major
+---
+
+### Changed
+
+- Duplicate keys now use last-value-wins (rewrite semantics) instead of storing multiple values
+- Internal data structure changed from `HashMap<String, Vec<String>>` to `HashMap<String, String>`
+
+### Removed
+
+- Removed `get_all()` method
+- Removed `add()` method

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! `.lenv` files use `: ` instead of `=` for key-value separation.
 //! Example: `GITHUB_TOKEN: gh_....`
+//!
+//! If a key appears multiple times in a file, the last value wins (rewrite semantics).
 
 use std::collections::HashMap;
 use std::fs;
@@ -41,7 +43,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 #[derive(Debug, Clone)]
 pub struct LinoEnv {
     file_path: String,
-    data: HashMap<String, Vec<String>>,
+    data: HashMap<String, String>,
 }
 
 impl LinoEnv {
@@ -67,7 +69,7 @@ impl LinoEnv {
 
     /// Read and parse the .lenv file.
     ///
-    /// Stores all instances of each key (duplicates are allowed).
+    /// If a key appears multiple times, the last value wins (rewrite semantics).
     ///
     /// # Errors
     ///
@@ -106,14 +108,15 @@ impl LinoEnv {
                 let key = line[..separator_index].trim().to_string();
                 let value = line[separator_index + 2..].to_string(); // Don't trim value to preserve spaces
 
-                self.data.entry(key).or_default().push(value);
+                // Last value wins (rewrite semantics)
+                self.data.insert(key, value);
             }
         }
 
         Ok(self)
     }
 
-    /// Get the last instance of a reference (key).
+    /// Get the value of a reference (key).
     ///
     /// # Arguments
     ///
@@ -121,7 +124,7 @@ impl LinoEnv {
     ///
     /// # Returns
     ///
-    /// The last value associated with the key, or None if not found.
+    /// The value associated with the key, or None if not found.
     ///
     /// # Examples
     ///
@@ -134,38 +137,10 @@ impl LinoEnv {
     /// ```
     #[must_use]
     pub fn get(&self, reference: &str) -> Option<String> {
-        self.data
-            .get(reference)
-            .and_then(|values| values.last().cloned())
+        self.data.get(reference).cloned()
     }
 
-    /// Get all instances of a reference (key).
-    ///
-    /// # Arguments
-    ///
-    /// * `reference` - The key to look up
-    ///
-    /// # Returns
-    ///
-    /// All values associated with the key, or an empty vector if not found.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use lino_env::LinoEnv;
-    /// let mut env = LinoEnv::new(".lenv");
-    /// env.add("KEY", "value1");
-    /// env.add("KEY", "value2");
-    /// assert_eq!(env.get_all("KEY"), vec!["value1", "value2"]);
-    /// ```
-    #[must_use]
-    pub fn get_all(&self, reference: &str) -> Vec<String> {
-        self.data.get(reference).cloned().unwrap_or_default()
-    }
-
-    /// Set all instances of a reference to a new value.
-    ///
-    /// Replaces all existing instances with a single new value.
+    /// Set a reference to a value.
     ///
     /// # Arguments
     ///
@@ -177,38 +152,11 @@ impl LinoEnv {
     /// ```
     /// use lino_env::LinoEnv;
     /// let mut env = LinoEnv::new(".lenv");
-    /// env.add("KEY", "old1");
-    /// env.add("KEY", "old2");
-    /// env.set("KEY", "new_value");
-    /// assert_eq!(env.get_all("KEY"), vec!["new_value"]);
+    /// env.set("KEY", "value");
+    /// assert_eq!(env.get("KEY"), Some("value".to_string()));
     /// ```
     pub fn set(&mut self, reference: &str, value: &str) -> &mut Self {
-        self.data
-            .insert(reference.to_string(), vec![value.to_string()]);
-        self
-    }
-
-    /// Add a new instance of a reference (allows duplicates).
-    ///
-    /// # Arguments
-    ///
-    /// * `reference` - The key to add
-    /// * `value` - The value to add
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use lino_env::LinoEnv;
-    /// let mut env = LinoEnv::new(".lenv");
-    /// env.add("KEY", "value1");
-    /// env.add("KEY", "value2");
-    /// assert_eq!(env.get_all("KEY"), vec!["value1", "value2"]);
-    /// ```
-    pub fn add(&mut self, reference: &str, value: &str) -> &mut Self {
-        self.data
-            .entry(reference.to_string())
-            .or_default()
-            .push(value.to_string());
+        self.data.insert(reference.to_string(), value.to_string());
         self
     }
 
@@ -236,10 +184,8 @@ impl LinoEnv {
     pub fn write(&self) -> io::Result<&Self> {
         let mut file = fs::File::create(&self.file_path)?;
 
-        for (key, values) in &self.data {
-            for value in values {
-                writeln!(file, "{key}: {value}")?;
-            }
+        for (key, value) in &self.data {
+            writeln!(file, "{key}: {value}")?;
         }
 
         Ok(self)
@@ -253,7 +199,7 @@ impl LinoEnv {
     ///
     /// # Returns
     ///
-    /// `true` if the key exists and has at least one value.
+    /// `true` if the key exists.
     ///
     /// # Examples
     ///
@@ -266,12 +212,10 @@ impl LinoEnv {
     /// ```
     #[must_use]
     pub fn has(&self, reference: &str) -> bool {
-        self.data
-            .get(reference)
-            .is_some_and(|values| !values.is_empty())
+        self.data.contains_key(reference)
     }
 
-    /// Delete all instances of a reference.
+    /// Delete a reference.
     ///
     /// # Arguments
     ///
@@ -313,32 +257,25 @@ impl LinoEnv {
         self.data.keys().cloned().collect()
     }
 
-    /// Get all entries as a `HashMap` (with last instance of each key).
+    /// Get all entries as a `HashMap`.
     ///
     /// # Returns
     ///
-    /// A `HashMap` with each key mapped to its last value.
+    /// A `HashMap` with each key mapped to its value.
     ///
     /// # Examples
     ///
     /// ```
     /// use lino_env::LinoEnv;
     /// let mut env = LinoEnv::new(".lenv");
-    /// env.add("KEY1", "value1a");
-    /// env.add("KEY1", "value1b");
+    /// env.set("KEY1", "value1");
     /// env.set("KEY2", "value2");
     /// let obj = env.to_hash_map();
-    /// assert_eq!(obj.get("KEY1"), Some(&"value1b".to_string()));
+    /// assert_eq!(obj.get("KEY1"), Some(&"value1".to_string()));
     /// ```
     #[must_use]
     pub fn to_hash_map(&self) -> HashMap<String, String> {
-        let mut result = HashMap::new();
-        for (key, values) in &self.data {
-            if let Some(last_value) = values.last() {
-                result.insert(key.clone(), last_value.clone());
-            }
-        }
-        result
+        self.data.clone()
     }
 }
 
@@ -461,15 +398,13 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_get_last_instance() {
-            let test_file = test_file("get_last_instance");
+        fn test_get_value() {
+            let test_file = test_file("get_value");
             cleanup(&test_file);
             let mut env = LinoEnv::new(&test_file);
-            env.add("API_KEY", "value1");
-            env.add("API_KEY", "value2");
-            env.add("API_KEY", "value3");
+            env.set("API_KEY", "value1");
 
-            assert_eq!(env.get("API_KEY"), Some("value3".to_string()));
+            assert_eq!(env.get("API_KEY"), Some("value1".to_string()));
             cleanup(&test_file);
         }
 
@@ -481,61 +416,36 @@ mod tests {
         }
     }
 
-    mod get_all_tests {
-        use super::*;
-
-        #[test]
-        fn test_get_all_instances() {
-            let test_file = test_file("get_all_instances");
-            cleanup(&test_file);
-            let mut env = LinoEnv::new(&test_file);
-            env.add("API_KEY", "value1");
-            env.add("API_KEY", "value2");
-            env.add("API_KEY", "value3");
-
-            assert_eq!(env.get_all("API_KEY"), vec!["value1", "value2", "value3"]);
-            cleanup(&test_file);
-        }
-
-        #[test]
-        fn test_get_all_nonexistent() {
-            let test_file = test_file("get_all_nonexistent");
-            let env = LinoEnv::new(&test_file);
-            assert!(env.get_all("NON_EXISTENT").is_empty());
-        }
-    }
-
     mod set_tests {
         use super::*;
 
         #[test]
-        fn test_set_replaces_all() {
-            let test_file = test_file("set_replaces_all");
+        fn test_set_overwrites() {
+            let test_file = test_file("set_overwrites");
             cleanup(&test_file);
             let mut env = LinoEnv::new(&test_file);
-            env.add("API_KEY", "value1");
-            env.add("API_KEY", "value2");
+            env.set("API_KEY", "value1");
             env.set("API_KEY", "new_value");
 
             assert_eq!(env.get("API_KEY"), Some("new_value".to_string()));
-            assert_eq!(env.get_all("API_KEY"), vec!["new_value"]);
             cleanup(&test_file);
         }
     }
 
-    mod add_tests {
+    mod duplicate_key_tests {
         use super::*;
 
         #[test]
-        fn test_add_duplicates() {
-            let test_file = test_file("add_duplicates");
+        fn test_duplicate_keys_last_value_wins() {
+            let test_file = test_file("duplicate_keys");
             cleanup(&test_file);
-            let mut env = LinoEnv::new(&test_file);
-            env.add("KEY", "value1");
-            env.add("KEY", "value2");
-            env.add("KEY", "value3");
+            // Write a file with duplicate keys manually
+            fs::write(&test_file, "A: value1\nA: value2\n").unwrap();
 
-            assert_eq!(env.get_all("KEY"), vec!["value1", "value2", "value3"]);
+            let mut env = LinoEnv::new(&test_file);
+            env.read().unwrap();
+
+            assert_eq!(env.get("A"), Some("value2".to_string()));
             cleanup(&test_file);
         }
     }
@@ -566,12 +476,11 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_delete_all_instances() {
-            let test_file = test_file("delete_all_instances");
+        fn test_delete() {
+            let test_file = test_file("delete");
             cleanup(&test_file);
             let mut env = LinoEnv::new(&test_file);
-            env.add("KEY", "value1");
-            env.add("KEY", "value2");
+            env.set("KEY", "value1");
             env.delete("KEY");
 
             assert!(!env.has("KEY"));
@@ -609,12 +518,11 @@ mod tests {
             let test_file = test_file("to_hash_map");
             cleanup(&test_file);
             let mut env = LinoEnv::new(&test_file);
-            env.add("KEY1", "value1a");
-            env.add("KEY1", "value1b");
+            env.set("KEY1", "value1");
             env.set("KEY2", "value2");
 
             let obj = env.to_hash_map();
-            assert_eq!(obj.get("KEY1"), Some(&"value1b".to_string()));
+            assert_eq!(obj.get("KEY1"), Some(&"value1".to_string()));
             assert_eq!(obj.get("KEY2"), Some(&"value2".to_string()));
             cleanup(&test_file);
         }
@@ -624,20 +532,17 @@ mod tests {
         use super::*;
 
         #[test]
-        fn test_persist_duplicates() {
-            let test_file = test_file("persist_duplicates");
+        fn test_persist_values() {
+            let test_file = test_file("persist_values");
             cleanup(&test_file);
             let mut env1 = LinoEnv::new(&test_file);
-            env1.add("KEY", "value1");
-            env1.add("KEY", "value2");
-            env1.add("KEY", "value3");
+            env1.set("KEY", "value");
             env1.write().unwrap();
 
             let mut env2 = LinoEnv::new(&test_file);
             env2.read().unwrap();
 
-            assert_eq!(env2.get_all("KEY"), vec!["value1", "value2", "value3"]);
-            assert_eq!(env2.get("KEY"), Some("value3".to_string()));
+            assert_eq!(env2.get("KEY"), Some("value".to_string()));
             cleanup(&test_file);
         }
     }


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Drop support for multiple values of the same variable name (fixes #28)
- Duplicate keys in `.lenv` files now use **last-value-wins** (rewrite semantics) — e.g., if a file contains `A: value1` then `A: value2`, reading it yields `A = "value2"`
- Removed `getAll()`/`get_all()` and `add()` methods from both JavaScript and Rust implementations
- Changed internal data structure from `Map<K, V[]>` / `HashMap<K, Vec<V>>` to `Map<K, V>` / `HashMap<K, V>`
- Updated all tests and documentation (READMEs) to reflect the new behavior
- Added changeset (JS major bump) and changelog fragment (Rust major bump)

## Test plan

- [x] JavaScript: 21 tests pass (`npm test` in `js/`)
- [x] Rust: 18 unit tests + 12 doc-tests pass (`cargo test` in `rust/`)
- [x] Rust: `cargo fmt --check` and `cargo clippy` pass
- [x] JavaScript: `eslint` and `prettier --check` pass
- [x] New test added: duplicate keys in file → last value wins
- [x] New test added: setting same key twice overwrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)