### PR TITLE
fix: support multi-line quoted lenv values

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-23T22:27:05.365Z for PR creation at branch issue-30-95febf8484cb for issue https://github.com/link-foundation/lino-env/issues/30

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-23T22:27:05.365Z for PR creation at branch issue-30-95febf8484cb for issue https://github.com/link-foundation/lino-env/issues/30

--- a/js/.changeset/multiline-quoted-values.md
+++ b/js/.changeset/multiline-quoted-values.md
@@ -1,0 +1,5 @@
+---
+'lino-env': patch
+---
+
+Support multi-line quoted values with double-quote and single-quote delimiters.

--- a/js/src/lino-env.mjs
+++ b/js/src/lino-env.mjs
@@ -1,5 +1,39 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
+function readMultilineQuotedValue(lines, startIndex, value) {
+  const openingQuoteMatch = value.match(/^\s*(['"])/);
+  if (!openingQuoteMatch) {
+    return null;
+  }
+
+  const quote = openingQuoteMatch[1];
+  const openingQuoteIndex = openingQuoteMatch[0].length - 1;
+  const firstPart = value.substring(openingQuoteIndex + 1);
+
+  // Preserve existing single-line quoted value behavior.
+  if (firstPart.includes(quote)) {
+    return null;
+  }
+
+  const parts = [firstPart];
+  for (let lineIndex = startIndex + 1; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    const closingQuoteIndex = line.indexOf(quote);
+
+    if (closingQuoteIndex !== -1) {
+      parts.push(line.substring(0, closingQuoteIndex));
+      return {
+        value: parts.join('\n'),
+        nextLineIndex: lineIndex,
+      };
+    }
+
+    parts.push(line);
+  }
+
+  return null;
+}
+
 /**
  * LinoEnv - A library to read and write .lenv files
  * .lenv files use `: ` instead of `=` for key-value separation
@@ -21,7 +55,8 @@ export class LinoEnv {
       this.data.clear();
 
       const lines = content.split('\n');
-      for (const line of lines) {
+      for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        const line = lines[lineIndex];
         // Skip completely empty lines
         if (line.trim() === '' || line.trim().startsWith('#')) {
           continue;
@@ -34,7 +69,17 @@ export class LinoEnv {
         }
 
         const key = line.substring(0, separatorIndex).trim();
-        const value = line.substring(separatorIndex + 2); // Don't trim the value to preserve spaces
+        let value = line.substring(separatorIndex + 2); // Don't trim the value to preserve spaces
+        const multilineQuotedValue = readMultilineQuotedValue(
+          lines,
+          lineIndex,
+          value
+        );
+
+        if (multilineQuotedValue) {
+          value = multilineQuotedValue.value;
+          lineIndex = multilineQuotedValue.nextLineIndex;
+        }
 
         // Last value wins (rewrite semantics)
         this.data.set(key, value);

--- a/js/tests/lino-env.test.mjs
+++ b/js/tests/lino-env.test.mjs
@@ -230,6 +230,50 @@ test('should handle values with spaces', () => {
   cleanup();
 });
 
+test('should handle multi-line double-quoted values', () => {
+  cleanup();
+  writeFileSync(
+    TEST_FILE,
+    `HIVE_TELEGRAM_BOT_CONFIGURATION: "
+TELEGRAM_BOT_TOKEN: 'xxx'
+TELEGRAM_ALLOWED_CHATS:
+  -1002975819706
+TELEGRAM_BOT_VERBOSE: true
+"
+AFTER: value
+`,
+    'utf-8'
+  );
+
+  const env = readLinoEnv(TEST_FILE);
+
+  assert.equal(
+    env.get('HIVE_TELEGRAM_BOT_CONFIGURATION'),
+    "\nTELEGRAM_BOT_TOKEN: 'xxx'\nTELEGRAM_ALLOWED_CHATS:\n  -1002975819706\nTELEGRAM_BOT_VERBOSE: true\n"
+  );
+  assert.equal(env.get('TELEGRAM_BOT_TOKEN'), undefined);
+  assert.equal(env.get('AFTER'), 'value');
+  cleanup();
+});
+
+test('should handle multi-line single-quoted values', () => {
+  cleanup();
+  writeFileSync(
+    TEST_FILE,
+    `SCRIPT: 'line1
+line2'
+AFTER: value
+`,
+    'utf-8'
+  );
+
+  const env = readLinoEnv(TEST_FILE);
+
+  assert.equal(env.get('SCRIPT'), 'line1\nline2');
+  assert.equal(env.get('AFTER'), 'value');
+  cleanup();
+});
+
 // Edge cases
 test('should handle non-existent file on read', () => {
   cleanup();

--- a/rust/changelog.d/20260423_225200_multiline_quoted_values.md
+++ b/rust/changelog.d/20260423_225200_multiline_quoted_values.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Support multi-line quoted values with double-quote and single-quote delimiters.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,11 +7,42 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, Write};
 use std::path::Path;
 
 /// Package version (matches Cargo.toml version).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn read_multiline_quoted_value(
+    lines: &[&str],
+    start_index: usize,
+    value: &str,
+) -> Option<(String, usize)> {
+    let trimmed_value = value.trim_start();
+    let quote = trimmed_value.chars().next()?;
+    if !matches!(quote, '"' | '\'') {
+        return None;
+    }
+
+    let first_part = &trimmed_value[quote.len_utf8()..];
+
+    // Preserve existing single-line quoted value behavior.
+    if first_part.contains(quote) {
+        return None;
+    }
+
+    let mut parts = vec![first_part.to_string()];
+    for (line_index, line) in lines.iter().enumerate().skip(start_index + 1) {
+        if let Some(closing_quote_index) = line.find(quote) {
+            parts.push(line[..closing_quote_index].to_string());
+            return Some((parts.join("\n"), line_index));
+        }
+
+        parts.push((*line).to_string());
+    }
+
+    None
+}
 
 /// `LinoEnv` - A struct to read and write `.lenv` files.
 ///
@@ -91,26 +122,35 @@ impl LinoEnv {
             return Ok(self);
         }
 
-        let file = fs::File::open(path)?;
-        let reader = BufReader::new(file);
-
-        for line in reader.lines() {
-            let line = line?;
+        let content = fs::read_to_string(path)?;
+        let lines: Vec<&str> = content.lines().collect();
+        let mut line_index = 0;
+        while line_index < lines.len() {
+            let line = lines[line_index];
             let trimmed = line.trim();
 
             // Skip empty lines and comments
             if trimmed.is_empty() || trimmed.starts_with('#') {
+                line_index += 1;
                 continue;
             }
 
             // Parse line with `: ` separator
             if let Some(separator_index) = line.find(": ") {
                 let key = line[..separator_index].trim().to_string();
-                let value = line[separator_index + 2..].to_string(); // Don't trim value to preserve spaces
+                let mut value = line[separator_index + 2..].to_string(); // Don't trim value to preserve spaces
+                if let Some((multiline_value, next_line_index)) =
+                    read_multiline_quoted_value(&lines, line_index, &value)
+                {
+                    value = multiline_value;
+                    line_index = next_line_index;
+                }
 
                 // Last value wins (rewrite semantics)
                 self.data.insert(key, value);
             }
+
+            line_index += 1;
         }
 
         Ok(self)
@@ -612,6 +652,49 @@ mod tests {
             let mut env2 = LinoEnv::new(&test_file_path);
             env2.read().unwrap();
             assert_eq!(env2.get("MESSAGE"), Some("Hello World".to_string()));
+            cleanup(&test_file_path);
+        }
+    }
+
+    mod multiline_quoted_value_tests {
+        use super::*;
+
+        #[test]
+        fn test_multi_line_double_quoted_values() {
+            let test_file_path = test_file("multiline_double_quoted");
+            cleanup(&test_file_path);
+            fs::write(
+                &test_file_path,
+                "HIVE_TELEGRAM_BOT_CONFIGURATION: \"\nTELEGRAM_BOT_TOKEN: 'xxx'\nTELEGRAM_ALLOWED_CHATS:\n  -1002975819706\nTELEGRAM_BOT_VERBOSE: true\n\"\nAFTER: value\n",
+            )
+            .unwrap();
+
+            let mut env = LinoEnv::new(&test_file_path);
+            env.read().unwrap();
+
+            assert_eq!(
+                env.get("HIVE_TELEGRAM_BOT_CONFIGURATION"),
+                Some(
+                    "\nTELEGRAM_BOT_TOKEN: 'xxx'\nTELEGRAM_ALLOWED_CHATS:\n  -1002975819706\nTELEGRAM_BOT_VERBOSE: true\n"
+                        .to_string()
+                )
+            );
+            assert_eq!(env.get("TELEGRAM_BOT_TOKEN"), None);
+            assert_eq!(env.get("AFTER"), Some("value".to_string()));
+            cleanup(&test_file_path);
+        }
+
+        #[test]
+        fn test_multi_line_single_quoted_values() {
+            let test_file_path = test_file("multiline_single_quoted");
+            cleanup(&test_file_path);
+            fs::write(&test_file_path, "SCRIPT: 'line1\nline2'\nAFTER: value\n").unwrap();
+
+            let mut env = LinoEnv::new(&test_file_path);
+            env.read().unwrap();
+
+            assert_eq!(env.get("SCRIPT"), Some("line1\nline2".to_string()));
+            assert_eq!(env.get("AFTER"), Some("value".to_string()));
             cleanup(&test_file_path);
         }
     }


### PR DESCRIPTION
## Summary

- Support `.lenv` values opened with `"` or `'` and closed on a later line in both JavaScript and Rust.
- Preserve the content between the delimiters, including newlines, as one string value.
- Skip consumed quoted-block lines so nested `: ` content is not parsed as separate `.lenv` keys.
- Add a patch changeset for the JavaScript package and a patch changelog fragment for the Rust package.

## Reproduction Covered

The JS and Rust tests cover the issue case where `HIVE_TELEGRAM_BOT_CONFIGURATION: "` wraps a YAML-like block containing lines such as `TELEGRAM_BOT_TOKEN: 'xxx'`, then closes on a later line. They also cover a single-quoted multi-line value.

## Parity Check

- Checked the JavaScript and Rust parser/API coverage for `: ` separators, duplicate-key last-wins behavior, spaces and colons in values, missing files, empty values, key lookup/mutation helpers, and multi-line quoted values.
- JavaScript's dotenvx-style `config()`, `get()`, and `set()` process environment helpers remain JavaScript-specific API surface.

## Test plan

- [x] `npm test` in `js/` (23 tests)
- [x] `npm run check` in `js/`
- [x] `node scripts/validate-changeset.mjs` in `js/`
- [x] `bun test` in `js/`
- [x] `deno test --allow-read --allow-write` in `js/`
- [x] `cargo fmt --all -- --check` in `rust/`
- [x] `cargo clippy --all-targets --all-features` in `rust/`
- [x] `node scripts/check-file-size.mjs` in `rust/`
- [x] `cargo test --all-features --verbose` in `rust/` (20 unit tests, 12 doc tests)
- [x] `cargo test --doc --verbose` in `rust/`
- [x] `cargo build --release --verbose` in `rust/`
- [x] `cargo package --list` in `rust/`

Fixes #30
